### PR TITLE
feat: Add function for saving image as csv format

### DIFF
--- a/IPAnalyzer/FormMain.Designer.cs
+++ b/IPAnalyzer/FormMain.Designer.cs
@@ -140,6 +140,7 @@ namespace IPAnalyzer
             toolStripMenuItemSaveImage = new ToolStripMenuItem();
             tiffToolStripMenuItem = new ToolStripMenuItem();
             pngToolStripMenuItem = new ToolStripMenuItem();
+            csvToolStripMenuItem = new ToolStripMenuItem();
             ipaToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator3 = new ToolStripSeparator();
             toolStripMenuItemReadParameter = new ToolStripMenuItem();
@@ -1235,7 +1236,7 @@ namespace IPAnalyzer
             // toolStripMenuItemSaveImage
             // 
             resources.ApplyResources(toolStripMenuItemSaveImage, "toolStripMenuItemSaveImage");
-            toolStripMenuItemSaveImage.DropDownItems.AddRange(new ToolStripItem[] { tiffToolStripMenuItem, pngToolStripMenuItem, ipaToolStripMenuItem });
+            toolStripMenuItemSaveImage.DropDownItems.AddRange(new ToolStripItem[] { tiffToolStripMenuItem, pngToolStripMenuItem, csvToolStripMenuItem, ipaToolStripMenuItem });
             toolStripMenuItemSaveImage.Name = "toolStripMenuItemSaveImage";
             // 
             // tiffToolStripMenuItem
@@ -1249,6 +1250,12 @@ namespace IPAnalyzer
             resources.ApplyResources(pngToolStripMenuItem, "pngToolStripMenuItem");
             pngToolStripMenuItem.Name = "pngToolStripMenuItem";
             pngToolStripMenuItem.Click += pngToolStripMenuItem_Click;
+            // 
+            // pngToolStripMenuItem
+            // 
+            resources.ApplyResources(csvToolStripMenuItem, "csvToolStripMenuItem");
+            csvToolStripMenuItem.Name = "csvToolStripMenuItem";
+            csvToolStripMenuItem.Click += csvToolStripMenuItem_Click;
             // 
             // ipaToolStripMenuItem
             // 
@@ -2079,6 +2086,7 @@ namespace IPAnalyzer
         private ToolStripMenuItem tiffToolStripMenuItem;
         private ToolStripMenuItem ipaToolStripMenuItem;
         private ToolStripMenuItem pngToolStripMenuItem;
+        private ToolStripMenuItem csvToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripButton toolStripButtonCircumferentialBlur;
         private Label labelResolution;

--- a/IPAnalyzer/FormMain.cs
+++ b/IPAnalyzer/FormMain.cs
@@ -2371,8 +2371,6 @@ public partial class FormMain : Form
                     WriteIntensityToCSV(writer, pseudoBitmap.SrcValuesGray, pseudoBitmap.Width);
                 }
             }
-
-            MessageBox.Show("CSVファイルとして保存しました。");
         }
         catch (Exception ex)
         {

--- a/IPAnalyzer/FormMain.resx
+++ b/IPAnalyzer/FormMain.resx
@@ -3603,6 +3603,9 @@ Center</value>
   <data name="pngToolStripMenuItem.Text" xml:space="preserve">
     <value>as PNG format (preserve brightness, contrast, masked area)</value>
   </data>
+  <data name="csvToolStripMenuItem.Text" xml:space="preserve">
+    <value>as CSV format</value>
+  </data>
   <data name="toolStripSplitButtonFindSpots.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>


### PR DESCRIPTION
### What  
Add a menu item to export the image data in CSV format.

### Why  
Exporting to CSV makes it easier for users to perform their own data analysis using familiar tools such as Excel or Python.

### How  
- Implemented a method in `FormMain.cs` to save image data as a CSV file.  
- Added a corresponding menu item in the resource file to trigger this functionality.

### Screenshots  
![AddMenuItemForSavingCsvFormat](https://github.com/user-attachments/assets/4f1d93ad-9a98-4253-bcaf-c276b813c0df)



### Others  
- **Note**: The test process has not been run.  
- I'm slightly concerned that this change might unintentionally affect other functionality. 
